### PR TITLE
fix bevry/getmac#2

### DIFF
--- a/src/lib/getmac.coffee
+++ b/src/lib/getmac.coffee
@@ -3,7 +3,6 @@
 {extractOpts} = require('extract-opts')
 
 # Prepare
-isWindows = process.platform.indexOf('win') is 0
 winRegex = /((?:[a-f0-9]{2}[:\-]){5}[a-f0-9]{2})\s+(\S+)/ig
 theRegex = /^(\S+)?\s+.*\s+((?:[a-f0-9]{2}[:\-]){5}[a-f0-9]{2})/ig
 macRegex = /(?:[a-f0-9]{2}[:\-]){5}[a-f0-9]{2}/ig
@@ -13,12 +12,11 @@ macRegex = /(?:[a-f0-9]{2}[:\-]){5}[a-f0-9]{2}/ig
 getMac = (opts, next) ->
 	# Prepare
 	[opts, next] = extractOpts(opts, next)
-	{data} = opts
 	iface = opts.interface
-	if opts.forceWindows
-		isWindows = true
-	if opts.forceUnix
-		isWindows = false
+	isWindows = process.platform.indexOf('win') is 0
+	if opts.os
+		isWindows = opts.os is 'win'
+	{data} = opts
 	data ?= null
 
 	# Command
@@ -30,7 +28,6 @@ getMac = (opts, next) ->
 		macs = {}
 		firstMac = null
 
-		
 		d = data.split("\n")
 		# Find a valid mac address
 		if /^\S+:/.exec(data[0])

--- a/src/test/everything-test.coffee
+++ b/src/test/everything-test.coffee
@@ -48,10 +48,11 @@ joe.describe 'getmac', (describe,it) ->
 			opts =
 				data: data
 				interface: 'eth0'
+				forceUnix: true
 			getMac opts, (err, macAddress) ->
 				return done(err)  if err
 				expect(err).to.be.null
-				expect(macAddress).to.eql('00:18:31:8A:41:C6')
+				expect(macAddress).to.eql('00:18:31:8a:41:c6')
 				return done()
 
 	describe 'preset ifconfig', (describe,it) ->
@@ -79,10 +80,32 @@ joe.describe 'getmac', (describe,it) ->
 		  """
 
 		it 'got the default mac address successfully', (done) ->
-			getMac {data}, (err, macAddress) ->
+			opts =
+				data: data
+				forceUnix: true
+			getMac opts, (err, macAddress) ->
 				return done(err)  if err
 				expect(err).to.be.null
 				expect(macAddress).to.eql('b8:8d:12:07:6b:ac')
+				return done()
+
+	describe 'preset ifconfig', (describe,it) ->
+		data = """
+			Physical Address    Transport Name
+			=================== ==========================================================
+			2C-3F-45-02-1B-32   \Device\Tcpip_{7E49B486-120A-4BC2-2114-B345A4D5C5}
+			10-13-17-BC-12-48   Media disconnected
+			22-B3-C5-30-76-78   \Device\Tcpip_{213E8D2A-1DBE-4240-8301-BE6F3EACAF9D}
+			00-05-2A-3C-78-00   \Device\Tcpip_{F01E3FC2-A5A1-6940-D1A1-C7521AEC4296}
+			2C-23-45-14-23-AD   Media disconnected
+		  """
+
+		it 'got the default Windows mac address successfully', (done) ->
+			forceWindows = true
+			getMac {data, forceWindows}, (err, macAddress) ->
+				return done(err)  if err
+				expect(err).to.be.null
+				expect(macAddress).to.eql('2c:3f:45:02:1b:32')
 				return done()
 
 	describe 'system', (describe,it) ->

--- a/src/test/everything-test.coffee
+++ b/src/test/everything-test.coffee
@@ -44,8 +44,11 @@ joe.describe 'getmac', (describe,it) ->
 		  RX bytes:230580 (225.1 KiB)  TX bytes:230580 (225.1 KiB)
 		  """
 
-		it 'got the default mac address successfully', (done) ->
-			getMac {data}, (err, macAddress) ->
+		it 'got the eth0 mac address successfully', (done) ->
+			opts =
+				data: data
+				interface: 'eth0'
+			getMac opts, (err, macAddress) ->
 				return done(err)  if err
 				expect(err).to.be.null
 				expect(macAddress).to.eql('00:18:31:8A:41:C6')
@@ -87,8 +90,6 @@ joe.describe 'getmac', (describe,it) ->
 			getMac (err, macAddress) ->
 				return done(err)  if err
 				expect(err).to.be.null
-				expect(macAddress).to.not.equal('00-00-00-00-00-00')
-				expect(macAddress).to.not.equal('00:00:00:00:00:00')
 				expect(macAddress).to.be.string
 				expect(isMac macAddress).to.be.true
 				return done()

--- a/src/test/everything-test.coffee
+++ b/src/test/everything-test.coffee
@@ -46,9 +46,9 @@ joe.describe 'getmac', (describe,it) ->
 
 		it 'got the eth0 mac address successfully', (done) ->
 			opts =
+				os: 'unix'
 				data: data
 				interface: 'eth0'
-				forceUnix: true
 			getMac opts, (err, macAddress) ->
 				return done(err)  if err
 				expect(err).to.be.null
@@ -80,29 +80,27 @@ joe.describe 'getmac', (describe,it) ->
 		  """
 
 		it 'got the default mac address successfully', (done) ->
-			opts =
-				data: data
-				forceUnix: true
-			getMac opts, (err, macAddress) ->
+			os = 'unix'
+			getMac {data, os}, (err, macAddress) ->
 				return done(err)  if err
 				expect(err).to.be.null
 				expect(macAddress).to.eql('b8:8d:12:07:6b:ac')
 				return done()
 
-	describe 'preset ifconfig', (describe,it) ->
+	describe 'preset getmac', (describe,it) ->
 		data = """
 			Physical Address    Transport Name
 			=================== ==========================================================
-			2C-3F-45-02-1B-32   \Device\Tcpip_{7E49B486-120A-4BC2-2114-B345A4D5C5}
+			2C-3F-45-02-1B-32   \\Device\\Tcpip_{7E49B486-120A-4BC2-2114-B345A4D5C5}
 			10-13-17-BC-12-48   Media disconnected
-			22-B3-C5-30-76-78   \Device\Tcpip_{213E8D2A-1DBE-4240-8301-BE6F3EACAF9D}
-			00-05-2A-3C-78-00   \Device\Tcpip_{F01E3FC2-A5A1-6940-D1A1-C7521AEC4296}
+			22-B3-C5-30-76-78   \\Device\\Tcpip_{213E8D2A-1DBE-4240-8301-BE6F3EACAF9D}
+			00-05-2A-3C-78-00   \\Device\\Tcpip_{F01E3FC2-A5A1-6940-D1A1-C7521AEC4296}
 			2C-23-45-14-23-AD   Media disconnected
 		  """
 
 		it 'got the default Windows mac address successfully', (done) ->
-			forceWindows = true
-			getMac {data, forceWindows}, (err, macAddress) ->
+			os = 'win'
+			getMac {data, os}, (err, macAddress) ->
 				return done(err)  if err
 				expect(err).to.be.null
 				expect(macAddress).to.eql('2c:3f:45:02:1b:32')


### PR DESCRIPTION
- remove `00:00:00:00:00:00` checks
- fix #2
- unify MAC address to the format `xx:xx:xx:xx:xx:xx`
- make tests work on Linux and Windows
