### PR TITLE
For Issue #9: Run 'ip link' if 'ifconfig' fails on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ script: "npm test"
 node_js:
   - "0.8"
   - "0.10"
+  - "0.12"
+  - "iojs"
 notifications:
   irc:
     - "irc.freenode.org#bevry-dev"

--- a/src/lib/getmac.coffee
+++ b/src/lib/getmac.coffee
@@ -16,7 +16,7 @@ getMac = (opts, next) ->
 	data ?= null
 
 	# Command
-	command = if isWindows then "getmac" else "ifconfig"
+	command = if isWindows then "getmac" else "ifconfig || ip link"
 
 	# Extract Mac
 	extractMac = (data, next) ->

--- a/src/test/everything-test.coffee
+++ b/src/test/everything-test.coffee
@@ -84,14 +84,15 @@ joe.describe 'getmac', (describe,it) ->
 
 	describe 'preset ip link', (describe,it) ->
 		data = """
-			1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default 
+			1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default
 			    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 			2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
 			    link/ether bc:76:4e:20:7d:dd brd ff:ff:ff:ff:ff:ff
 			3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
 			    link/ether bc:76:4e:20:99:be brd ff:ff:ff:ff:ff:ff
-			4: sit0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN mode DEFAULT group default 
+			4: sit0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN mode DEFAULT group default
 			    link/sit 0.0.0.0 brd 0.0.0.0
+		  """
 
 		it 'got the default mac address successfully', (done) ->
 			getMac {data}, (err, macAddress) ->

--- a/src/test/everything-test.coffee
+++ b/src/test/everything-test.coffee
@@ -82,6 +82,24 @@ joe.describe 'getmac', (describe,it) ->
 				expect(macAddress).to.eql('b8:8d:12:07:6b:ac')
 				return done()
 
+	describe 'preset ip link', (describe,it) ->
+		data = """
+			1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default 
+			    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+			2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
+			    link/ether bc:76:4e:20:7d:dd brd ff:ff:ff:ff:ff:ff
+			3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
+			    link/ether bc:76:4e:20:99:be brd ff:ff:ff:ff:ff:ff
+			4: sit0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN mode DEFAULT group default 
+			    link/sit 0.0.0.0 brd 0.0.0.0
+
+		it 'got the default mac address successfully', (done) ->
+			getMac {data}, (err, macAddress) ->
+				return done(err)  if err
+				expect(err).to.be.null
+				expect(macAddress).to.eql('bc:76:4e:20:7d:dd')
+				return done()
+
 	describe 'system', (describe,it) ->
 		it 'got the default mac address successfully', (done) ->
 			getMac (err, macAddress) ->


### PR DESCRIPTION
For up-to-date Linux distros, Arch and even Debian, net-tools (ifconfig) is being deprecated:
https://wiki.debian.org/NetToolsDeprecation
https://www.archlinux.org/news/deprecation-of-net-tools/

The replacement is the iproute2 set of commands:
https://dougvitale.wordpress.com/2011/12/21/deprecated-linux-networking-commands-and-their-replacements/

This change adds a shell "or" in between, in case ifconfig is not present on the system.