### PR TITLE
Fixes #9: Run 'ip link' if ifconfig fails on Linux

### DIFF
--- a/src/lib/getmac.coffee
+++ b/src/lib/getmac.coffee
@@ -16,7 +16,7 @@ getMac = (opts, next) ->
 	data ?= null
 
 	# Command
-	command = if isWindows then "getmac" else "ifconfig"
+	command = if isWindows then "getmac" else "ifconfig || ip link"
 
 	# Extract Mac
 	extractMac = (data, next) ->

--- a/src/test/everything-test.coffee
+++ b/src/test/everything-test.coffee
@@ -82,6 +82,25 @@ joe.describe 'getmac', (describe,it) ->
 				expect(macAddress).to.eql('b8:8d:12:07:6b:ac')
 				return done()
 
+	describe 'preset ip link', (describe,it) ->
+		data = """
+			1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default
+			    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+			2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
+			    link/ether bc:76:4e:20:7d:dd brd ff:ff:ff:ff:ff:ff
+			3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
+			    link/ether bc:76:4e:20:99:be brd ff:ff:ff:ff:ff:ff
+			4: sit0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN mode DEFAULT group default
+			    link/sit 0.0.0.0 brd 0.0.0.0
+		  """
+
+		it 'got the default mac address successfully', (done) ->
+			getMac {data}, (err, macAddress) ->
+				return done(err)  if err
+				expect(err).to.be.null
+				expect(macAddress).to.eql('bc:76:4e:20:7d:dd')
+				return done()
+
 	describe 'system', (describe,it) ->
 		it 'got the default mac address successfully', (done) ->
 			getMac (err, macAddress) ->


### PR DESCRIPTION
This update adds a shell 'or' after the ifconfig
command on Linux machines, to account for the case
where net-tools has been supplanted by iproute2.

Fixed up from PR#10