### PR TITLE
Add '-a' to ifconfig command

### DIFF
--- a/src/lib/getmac.coffee
+++ b/src/lib/getmac.coffee
@@ -16,7 +16,7 @@ getMac = (opts, next) ->
 	data ?= null
 
 	# Command
-	command = if isWindows then "getmac" else "ifconfig || ip link"
+	command = if isWindows then "getmac" else "ifconfig -a || ip link"
 
 	# Extract Mac
 	extractMac = (data, next) ->


### PR DESCRIPTION
Default behavior of ifconfig is to only show interfaces that are up.  This yields inconsistent results on systems with interfaces that are hot plugged. Adding -a to ifconfig returns all interfaces, even down.  For ip link, this is not an issue as it will show all interfaces by default.