### PR TITLE
Remove browser field and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,6 @@ Get the mac address of the current machine you are on
 <li>Executable: <code>getmac-node</code></li>
 <li>Module: <code>require('getmac')</code></li></ul>
 
-<a href="http://browserify.org" title="Browserify lets you require('modules') in the browser by bundling up all of your dependencies"><h3>Browserify</h3></a><ul>
-<li>Install: <code>npm install --save getmac</code></li>
-<li>Module: <code>require('getmac')</code></li>
-<li>CDN URL: <code>//wzrd.in/bundle/getmac@1.2.1</code></li></ul>
-
-<a href="http://enderjs.com" title="Ender is a full featured package manager for your browser"><h3>Ender</h3></a><ul>
-<li>Install: <code>ender add getmac</code></li>
-<li>Module: <code>require('getmac')</code></li></ul>
-
 <h3><a href="https://github.com/bevry/editions" title="Editions are the best way to produce and consume packages you care about.">Editions</a></h3>
 
 <p>This package is published with the following editions:</p>

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     }
   ],
   "main": "es5/lib/getmac.js",
-  "browser": "es5/lib/getmac.js",
   "bin": {
     "getmac-node": "bin/getmac-node"
   },


### PR DESCRIPTION
This is not a browser module. These instructions were incorrect.

Closes #18 #19.