### PR TITLE
Fix running as a restricted user

### DIFF
--- a/source/index.coffee
+++ b/source/index.coffee
@@ -44,7 +44,7 @@ getMac = (opts, next) ->
 	iface ?= null
 
 	# Command
-	command = if isWindows then "getmac" else "ifconfig -a || ip link"
+	command = if isWindows then "getmac" else "/sbin/ifconfig -a || /sbin/ip link"
 
 	# Extract Mac
 	extractMac = (data, next) ->


### PR DESCRIPTION
ifconfig and ip commands are traditionally in /sbin on UNIX,
even OSX complies to this.

Unfortunately, only root and other administrator users have
/sbin in their PATH and the getmac module fails of NodeJs is
running as a restricted user.

Execute ifconfig and ip commands using their full paths.

Signed-off-by: Böszörményi Zoltán <zboszor@pr.hu>