### PR TITLE
Fixed getmac on some windows versions

### DIFF
--- a/source/index.coffee
+++ b/source/index.coffee
@@ -44,7 +44,7 @@ getMac = (opts, next) ->
 	iface ?= null
 
 	# Command
-	command = if isWindows then "%SystemRoot%/System32/getmac.exe" else "/sbin/ifconfig -a || /sbin/ip link"
+	command = if isWindows then "%SystemRoot%/System32/ipconfig.exe /all" else "/sbin/ifconfig -a || /sbin/ip link"
 
 	# Extract Mac
 	extractMac = (data, next) ->


### PR DESCRIPTION
On some windows versions, System32/getmac.exe drops an error : 
![Proof](https://i.gyazo.com/d4c2a830c17f514fbe101147c399769a.png)
(Translations : Error : Not found, this is not dropped by CMD as the file exists and CMD would drop a much longer message saying this command can't be found)

I think this is because of this : ![Doc](https://i.gyazo.com/6851e428920c50d84a1c3b1d3c2b814d.png)
I don't think this was meant to work on desktop windows, even if it does, sometimes it doesn't

Replacing getmac.exe by ipconfig.exe /all works very well, i've been editing my node_modules with this for quite some time on a production project and it works fine.