### PR TITLE
Remove unused import NetworkInterfaceInfo

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -1,5 +1,5 @@
 // Prepare
-import { networkInterfaces, NetworkInterfaceInfo } from 'os'
+import { networkInterfaces } from 'os'
 const macRegex = /(?:[a-z0-9]{1,2}[:-]){5}[a-z0-9]{1,2}/i
 const zeroRegex = /(?:[0]{1,2}[:-]){5}[0]{1,2}/
 


### PR DESCRIPTION
If we use this package with the rule noUnusedLocals activated in tsconfig, we'll get an error with the compilation